### PR TITLE
feat/no-async-without-trycatch

### DIFF
--- a/docs/rules/no-await-without-trycatch.md
+++ b/docs/rules/no-await-without-trycatch.md
@@ -1,0 +1,33 @@
+# disallow awaits outside of try-catch blocks (no-await-without-trycatch)
+
+Asynchronous function calls might fail. Calls using ES6 async-await syntax should wrap `await` calls in a try-catch block.
+
+## Rule Details
+
+This rule disallows `await` expressions outside of try-catch blocks.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-throw-sync-func: "error"*/
+async function f() {
+    await g()
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-throw-sync-func: "error"*/
+async function f() {
+    try {
+        await g()
+    } catch (e) {
+        // handle the error
+    }
+}
+```
+
+## Recommendation
+
+As the use of `await`s may be nested, setting this rule to `warn` rather than `error` may prove to be useful without being overly intrusive.

--- a/docs/rules/no-await-without-trycatch.md
+++ b/docs/rules/no-await-without-trycatch.md
@@ -9,7 +9,7 @@ This rule disallows `await` expressions outside of try-catch blocks.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-throw-sync-func: "error"*/
+/*eslint no-await-without-trycatch: "error"*/
 async function f() {
     await g()
 }
@@ -18,7 +18,7 @@ async function f() {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-throw-sync-func: "error"*/
+/*eslint no-await-without-trycatch: "error"*/
 async function f() {
     try {
         await g()

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var requireIndex = require("requireindex");
+const requireIndex = require("requireindex");
 
 //------------------------------------------------------------------------------
 // Plugin Definition

--- a/lib/rules/no-await-without-trycatch.js
+++ b/lib/rules/no-await-without-trycatch.js
@@ -1,0 +1,17 @@
+module.exports = {
+    meta: {
+      type: "suggestion",
+    },
+    create (context) {
+      return {
+        AwaitExpression(throwNode) {
+          if (context.getAncestors().every(node => node.type != 'TryStatement')) {
+            context.report({
+              node: throwNode,
+              message: `Await expressions should be executed in a try-catch block.`
+            })
+          }
+        },
+      }
+    }
+  }

--- a/tests/rules/no-await-without-trycatch.js
+++ b/tests/rules/no-await-without-trycatch.js
@@ -4,14 +4,14 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var rule = require("../../lib/rules/no-await-without-trycatch");
-var RuleTester = require('eslint').RuleTester;
+const rule = require("../../lib/rules/no-await-without-trycatch");
+const RuleTester = require('eslint').RuleTester;
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-var eslintTester = new RuleTester();
+const eslintTester = new RuleTester();
 
 eslintTester.run("no-await-without-trycatch", rule, {
   valid: [

--- a/tests/rules/no-await-without-trycatch.js
+++ b/tests/rules/no-await-without-trycatch.js
@@ -1,0 +1,45 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../lib/rules/no-await-without-trycatch");
+var RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+
+eslintTester.run("no-await-without-trycatch", rule, {
+  valid: [
+    {
+        // Await in try-catch block
+        code: `
+        async function f() {
+            try {
+                await g()
+            } catch (e) {
+                console.error(e)
+            }
+        }`,
+        parserOptions: { ecmaVersion: 8, sourceType: "module" }
+    }
+  ],
+  invalid: [
+    {
+      // Await not in try-catch block
+      code: `
+        async function f() {
+            const x = await g()
+            return x
+        }`,
+        parserOptions: { ecmaVersion: 8, sourceType: "module" },
+      errors: [
+        { message: "Await expressions should be executed in a try-catch block." }
+      ],
+    }
+  ]
+});

--- a/tests/rules/no-throw-sync-func.js
+++ b/tests/rules/no-throw-sync-func.js
@@ -4,14 +4,14 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var rule = require("../../lib/rules/no-throw-sync-func");
-var RuleTester = require('eslint').RuleTester;
+const rule = require("../../lib/rules/no-throw-sync-func");
+const RuleTester = require('eslint').RuleTester;
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-var eslintTester = new RuleTester();
+const eslintTester = new RuleTester();
 
 eslintTester.run("no-throw-sync-func", rule, {
   valid: [{


### PR DESCRIPTION
A simple and straightforward rule to flag whether an `AwaitExpression` is within a `TryStatement`.

The implementation works by simply checking whether any of the ancestors of the `AwaitExpression` is a `TryStatement`, and reports the line of code if it is not.