### PR TITLE
feat/promise-catch: add cases where a synchronous function returns a new Promise

### DIFF
--- a/lib/rules/promise-catch.js
+++ b/lib/rules/promise-catch.js
@@ -131,6 +131,31 @@ function isCalleeNotUsingCatchExpression (node) {
         (node.type === 'MemberExpression' && node.property.name !== 'catch'))// e.g. f().then(...)
 }
 
+/**
+ * Finds the AST node of the function being called in a CallExpression
+ * @param {CallExpression} node ASTNode of type CallExpression
+ * @param {Scope} scope The scope of the node
+ */
+function findFunctionNodeFromCallExpression (node, scope) {
+    if (node && node.type !== 'CallExpression') return null
+    // Find out whether the called function is async
+    const functionName = getCalledFunctionIdentifierName(node)
+
+    // Could not get the function name
+    if (functionName === null) return null
+
+    const functionVariable = scope.set.get(functionName)
+
+    // Could not find the Variable
+    if (!functionVariable) return null
+
+    // Get the AST node of the function declaration that is being called
+    const functionDefs = functionVariable.defs
+    const lastFunctionDef = functionDefs[functionDefs.length - 1] // in case of repeated function definitions
+
+    return lastFunctionDef.node
+}
+
 module.exports = {
     meta: {
         type: "suggestion",
@@ -140,21 +165,10 @@ module.exports = {
             "ExpressionStatement > CallExpression": function(callExpr) {
                 const scope = context.getScope()
 
-                // Find out whether the called function is async
-                const functionName = getCalledFunctionIdentifierName(callExpr)
+                // Get the AST node of the function that is being called
+                const functionNode = findFunctionNodeFromCallExpression(callExpr, scope)
 
-                // Could not get the function name
-                if (functionName === null) return
-
-                const functionVariable = scope.set.get(functionName)
-
-                // Could not find the Variable
-                if (!functionVariable) return
-
-                // Get the AST node of the function declaration that is being called
-                const functionDefs = functionVariable.defs
-                const lastFunctionDef = functionDefs[functionDefs.length - 1] // in case of repeated function definitions
-                const functionNode = lastFunctionDef.node
+                if (!functionNode) return
 
                 // Function being called does not return a Promise
                 if (!isFunctionReturningPromise(functionNode)) return

--- a/lib/rules/promise-catch.js
+++ b/lib/rules/promise-catch.js
@@ -23,6 +23,10 @@ function getCalledFunctionIdentifierName (node) {
     }
 }
 
+/**
+ *  Utility functions to detect async function nodes
+ * */
+
 function isAsyncFunctionDeclaration (node) {
     return node && node.type === 'FunctionDeclaration' && node.async
 }
@@ -35,8 +39,54 @@ function isAsyncVariableDeclarator (node) {
     return node && node.type === 'VariableDeclarator' && isAsyncArrowFunctionExpression(node.init)
 }
 
+/**
+ *  Utility functions to for synchronous function nodes
+ * */
+
+ /**
+  * Whether a ReturnStatement explicitly returns a promise
+  * @param {ReturnStatement} node 
+  */
+function isReturnStatementPromise (node) {
+    return node && node.type === 'ReturnStatement' &&
+        (   // return new Promise(...)
+            node.argument && node.argument.type === 'NewExpression' && node.argument.callee && node.argument.callee.type === 'Identifier' && node.argument.callee.name === 'Promise' ||
+            // return Promise.resolve() or Promise.reject()
+            node.argument && node.argument.type === 'CallExpression' && node.argument.callee && node.argument.callee.type === 'MemberExpression' && node.argument.callee.object && node.argument.callee.object.type === 'Identifier' && node.argument.callee.object.name === 'Promise' && node.argument.callee.property.type === 'Identifier' && node.argument.callee.property && ['resolve', 'reject'].includes(node.argument.callee.property.name)
+        )
+}
+
+/**
+ * Function to detect whether a synchronous function node returns a Promise
+ * @param {ASTNode | undefined} node 
+ * @returns {Boolean}
+ */
+function isSyncFunctionReturningPromise (node) {
+    if (node === undefined) return false
+
+    switch (node.type) {
+        case 'FunctionDeclaration':
+        case 'ArrowFunctionExpression':
+        case 'FunctionExpression':
+            return isSyncFunctionReturningPromise(node.body)
+        case 'ReturnStatement': // base case
+            return isReturnStatementPromise(node)
+        case 'BlockStatement':
+            return node.body.some(x => isSyncFunctionReturningPromise(x))
+        case 'VariableDeclaration':
+            return node.declarations.some(x => isSyncFunctionReturningPromise(x))
+        case 'VariableDeclarator':
+            return isSyncFunctionReturningPromise(node.init)
+        case 'IfStatement':
+            return isSyncFunctionReturningPromise(node.consequent) || isSyncFunctionReturningPromise(node.alternate)
+        default:
+            return false // TODO: return Identifier
+    }
+}
+
+
 function isFunctionNodeAsync (node) {
-    return isAsyncFunctionDeclaration(node) || isAsyncVariableDeclarator(node)
+    return isAsyncFunctionDeclaration(node) || isAsyncVariableDeclarator(node) || isSyncFunctionReturningPromise(node)
 }
 
 function isCalleeNotUsingCatchExpression (node) {

--- a/lib/rules/promise-catch.js
+++ b/lib/rules/promise-catch.js
@@ -39,25 +39,47 @@ function isAsyncVariableDeclarator (node) {
     return node && node.type === 'VariableDeclarator' && isAsyncArrowFunctionExpression(node.init)
 }
 
+function isFunctionNodeAsync (node) {
+    return isAsyncFunctionDeclaration(node) || isAsyncVariableDeclarator(node)
+}
+
 /**
  *  Utility functions to for synchronous function nodes
  * */
 
- /**
-  * Whether a ReturnStatement explicitly returns a promise
-  * @param {ReturnStatement} node 
-  */
+/**
+ * Whether an Identifier is a Promise literal
+ * @param {Identifier} node 
+ */
+function isIdentifierPromiseLiteral (node) {
+    return node && node.type === 'Identifier' && node.name === 'Promise'
+}
+
+/**
+ * Whether a NewExpression is constructing a Promise
+ * @example return new Promise(...)
+ * @param {NewExpression} node 
+ */
+function isNewExpressionConstructingPromise (node) {
+    return node && node.type === 'NewExpression' && isIdentifierPromiseLiteral(node.callee)
+}
+
+/**
+ * Whether a ReturnStatement explicitly returns a promise
+ * @param {ReturnStatement} node 
+ */
 function isReturnStatementPromise (node) {
     return node && node.type === 'ReturnStatement' &&
         (   // return new Promise(...)
-            node.argument && node.argument.type === 'NewExpression' && node.argument.callee && node.argument.callee.type === 'Identifier' && node.argument.callee.name === 'Promise' ||
+            isNewExpressionConstructingPromise(node.argument) ||
             // return Promise.resolve() or Promise.reject()
             node.argument && node.argument.type === 'CallExpression' && node.argument.callee && node.argument.callee.type === 'MemberExpression' && node.argument.callee.object && node.argument.callee.object.type === 'Identifier' && node.argument.callee.object.name === 'Promise' && node.argument.callee.property.type === 'Identifier' && node.argument.callee.property && ['resolve', 'reject'].includes(node.argument.callee.property.name)
         )
 }
 
 /**
- * Function to detect whether a synchronous function node returns a Promise
+ * Function to detect whether a synchronous function node returns a Promise.
+ * Currently this only detects cases where a return
  * @param {ASTNode | undefined} node 
  * @returns {Boolean}
  */
@@ -84,9 +106,8 @@ function isSyncFunctionReturningPromise (node) {
     }
 }
 
-
-function isFunctionNodeAsync (node) {
-    return isAsyncFunctionDeclaration(node) || isAsyncVariableDeclarator(node) || isSyncFunctionReturningPromise(node)
+function isFunctionReturningPromise (node) {
+    return isFunctionNodeAsync(node) || isSyncFunctionReturningPromise(node)
 }
 
 function isCalleeNotUsingCatchExpression (node) {
@@ -121,7 +142,7 @@ module.exports = {
                 const functionNode = lastFunctionDef.node
 
                 // Function being called does not return a Promise
-                if (!isFunctionNodeAsync(functionNode)) return
+                if (!isFunctionReturningPromise(functionNode)) return
 
                 // Async function called without using await
                 const callee = callExpr.callee

--- a/lib/rules/promise-catch.js
+++ b/lib/rules/promise-catch.js
@@ -6,7 +6,7 @@
  * @returns {String | null}
  */
 function getCalledFunctionIdentifierName (node) {
-    if (node === undefined) return null
+    if (!node) return null
 
     switch (node.type) {
         case 'Identifier':
@@ -99,7 +99,7 @@ function isReturnStatementPromise (node) {
  * @returns {Boolean}
  */
 function isSyncFunctionReturningPromise (node) {
-    if (node === undefined) return false
+    if (!node) return false
 
     switch (node.type) {
         case 'FunctionDeclaration':

--- a/lib/rules/promise-catch.js
+++ b/lib/rules/promise-catch.js
@@ -64,6 +64,18 @@ function isNewExpressionConstructingPromise (node) {
     return node && node.type === 'NewExpression' && isIdentifierPromiseLiteral(node.callee)
 }
 
+function isCallExpression (node) {
+    return node && node.type === 'CallExpression'
+}
+
+function isMemberExpression (node) {
+    return node && node.type === 'MemberExpression'
+}
+
+function isIdentifierResolveOrReject (node) {
+    return node && node.type === 'Identifier' && ['resolve','reject'].includes(node.name)
+}
+
 /**
  * Whether a ReturnStatement explicitly returns a promise
  * @param {ReturnStatement} node 
@@ -73,7 +85,10 @@ function isReturnStatementPromise (node) {
         (   // return new Promise(...)
             isNewExpressionConstructingPromise(node.argument) ||
             // return Promise.resolve() or Promise.reject()
-            node.argument && node.argument.type === 'CallExpression' && node.argument.callee && node.argument.callee.type === 'MemberExpression' && node.argument.callee.object && node.argument.callee.object.type === 'Identifier' && node.argument.callee.object.name === 'Promise' && node.argument.callee.property.type === 'Identifier' && node.argument.callee.property && ['resolve', 'reject'].includes(node.argument.callee.property.name)
+            isCallExpression(node.argument) &&
+            isMemberExpression(node.argument.callee) &&
+            isIdentifierPromiseLiteral(node.argument.callee.object) &&
+            isIdentifierResolveOrReject(node.argument.callee.property)
         )
 }
 

--- a/lib/rules/promise-catch.js
+++ b/lib/rules/promise-catch.js
@@ -23,20 +23,48 @@ function getCalledFunctionIdentifierName (node) {
     }
 }
 
+function isIdentifier(node) {
+    return node && node.type === 'Identifier'
+}
+
+function isFunctionDeclaration(node) {
+    return node && node.type === 'FunctionDeclaration'
+}
+
+function isArrowFunctionExpression(node) {
+    return node && node.type === 'ArrowFunctionExpression'
+}
+
+function isVariableDeclarator(node) {
+    return node && node.type === 'VariableDeclarator'
+}
+
+function isNewExpression(node) {
+    return node && node.type === 'NewExpression'
+}
+
+function isCallExpression (node) {
+    return node && node.type === 'CallExpression'
+}
+
+function isMemberExpression (node) {
+    return node && node.type === 'MemberExpression'
+}
+
 /**
  *  Utility functions to detect async function nodes
  * */
 
 function isAsyncFunctionDeclaration (node) {
-    return node && node.type === 'FunctionDeclaration' && node.async
+    return isFunctionDeclaration(node) && node.async
 }
 
 function isAsyncArrowFunctionExpression (node) {
-    return node && node.type === 'ArrowFunctionExpression' && node.async
+    return isArrowFunctionExpression(node) && node.async
 }
 
 function isAsyncVariableDeclarator (node) {
-    return node && node.type === 'VariableDeclarator' && isAsyncArrowFunctionExpression(node.init)
+    return isVariableDeclarator(node) && isAsyncArrowFunctionExpression(node.init)
 }
 
 function isFunctionNodeAsync (node) {
@@ -52,7 +80,7 @@ function isFunctionNodeAsync (node) {
  * @param {Identifier} node 
  */
 function isIdentifierPromiseLiteral (node) {
-    return node && node.type === 'Identifier' && node.name === 'Promise'
+    return isIdentifier(node) && node.name === 'Promise'
 }
 
 /**
@@ -61,19 +89,11 @@ function isIdentifierPromiseLiteral (node) {
  * @param {NewExpression} node 
  */
 function isNewExpressionConstructingPromise (node) {
-    return node && node.type === 'NewExpression' && isIdentifierPromiseLiteral(node.callee)
-}
-
-function isCallExpression (node) {
-    return node && node.type === 'CallExpression'
-}
-
-function isMemberExpression (node) {
-    return node && node.type === 'MemberExpression'
+    return isNewExpression(node) && isIdentifierPromiseLiteral(node.callee)
 }
 
 function isIdentifierResolveOrReject (node) {
-    return node && node.type === 'Identifier' && ['resolve','reject'].includes(node.name)
+    return isIdentifier(node) && ['resolve','reject'].includes(node.name)
 }
 
 /**
@@ -126,9 +146,8 @@ function isFunctionReturningPromise (node) {
 }
 
 function isCalleeNotUsingCatchExpression (node) {
-    return node &&
-        (node.type === 'Identifier' || // e.g. f()
-        (node.type === 'MemberExpression' && node.property.name !== 'catch'))// e.g. f().then(...)
+    return isIdentifier(node) || // e.g. f()
+        (isMemberExpression(node) && node.property.name !== 'catch')// e.g. f().then(...)
 }
 
 /**
@@ -156,28 +175,39 @@ function findFunctionNodeFromCallExpression (node, scope) {
     return lastFunctionDef.node
 }
 
+/**
+ * Tests whether a call expression should be using a catch statement
+ * @param {CallExpression} node ASTNode of type CallExpression
+ * @param {Scope} scope The scope of the CallExpression
+ * @returns {Boolean | null}
+ */
+function isCallExpressionNotUsingCatch(node, scope) {
+    if (!node || node.type !== 'CallExpression' || !scope) return null
+
+    // Get the AST node of the function that is being called
+    const functionNode = findFunctionNodeFromCallExpression(node, scope)
+
+    if (!functionNode) return null
+
+    // Function being called does not return a Promise
+    if (!isFunctionReturningPromise(functionNode)) return false
+
+    // Async function called without using await
+    return isCalleeNotUsingCatchExpression(node.callee)
+}
+
 module.exports = {
     meta: {
         type: "suggestion",
     },
     create (context) {
         return {
-            "ExpressionStatement > CallExpression": function(callExpr) {
+            "ExpressionStatement > CallExpression": function(node) {
                 const scope = context.getScope()
 
-                // Get the AST node of the function that is being called
-                const functionNode = findFunctionNodeFromCallExpression(callExpr, scope)
-
-                if (!functionNode) return
-
-                // Function being called does not return a Promise
-                if (!isFunctionReturningPromise(functionNode)) return
-
-                // Async function called without using await
-                const callee = callExpr.callee
-                if (isCalleeNotUsingCatchExpression(callee)) {
+                if (isCallExpressionNotUsingCatch(node, scope)) {
                     context.report({
-                        node: callExpr,
+                        node,
                         message: `Missing catch statement.`
                     })
                 }

--- a/lib/rules/promise-catch.js
+++ b/lib/rules/promise-catch.js
@@ -19,7 +19,7 @@ function getCalledFunctionIdentifierName (node) {
         case 'Super':
             return getCalledFunctionIdentifierName(node.parent.property) // try backtracking
         default:
-            throw new Error(`Unknown node encountered in typesafe/promise-catch:\t${node.type}`)
+            return null
     }
 }
 

--- a/lib/rules/promise-catch.js
+++ b/lib/rules/promise-catch.js
@@ -32,6 +32,12 @@ function isFunctionNodeAsync (node) {
     return isAsyncFunctionDeclaration(node) || isAsyncVariableDeclarator(node)
 }
 
+function isCalleeNotUsingCatchExpression (node) {
+    return node &&
+        (node.type === 'Identifier' || // e.g. f()
+        (node.type === 'MemberExpression' && node.property.name !== 'catch'))// e.g. f().then(...)
+}
+
 module.exports = {
     meta: {
         type: "suggestion",
@@ -44,28 +50,29 @@ module.exports = {
                 // Find out whether the called function is async
                 const functionName = getCalledFunctionIdentifierName(callExpr)
 
+                // Could not get the function name
                 if (functionName === null) return
 
                 const functionVariable = scope.set.get(functionName)
 
-                if (functionVariable) {
-                    const functionDefs = functionVariable.defs
-                    const lastFunctionDef = functionDefs[functionDefs.length - 1] // in case of repeated function definitions
-                    const functionNode = lastFunctionDef.node
+                // Could not find the Variable
+                if (!functionVariable) return
 
-                    // Async function called without using await
-                    if (isFunctionNodeAsync(functionNode)) {
-                        const callee = callExpr.callee
-                        if (
-                            callee.type === 'Identifier' || // e.g. f()
-                            (callee.type === 'MemberExpression' && callee.property.name !== 'catch') // e.g. f().then(...)
-                        ) {
-                            context.report({
-                                node: callExpr,
-                                message: `Missing catch statement.`
-                            })
-                        }
-                    }
+                // Get the AST node of the function declaration that is being called
+                const functionDefs = functionVariable.defs
+                const lastFunctionDef = functionDefs[functionDefs.length - 1] // in case of repeated function definitions
+                const functionNode = lastFunctionDef.node
+
+                // Function being called does not return a Promise
+                if (!isFunctionNodeAsync(functionNode)) return
+
+                // Async function called without using await
+                const callee = callExpr.callee
+                if (isCalleeNotUsingCatchExpression(callee)) {
+                    context.report({
+                        node: callExpr,
+                        message: `Missing catch statement.`
+                    })
                 }
             },
         }

--- a/lib/rules/promise-catch.js
+++ b/lib/rules/promise-catch.js
@@ -71,6 +71,10 @@ function isFunctionNodeAsync (node) {
     return isAsyncFunctionDeclaration(node) || isAsyncVariableDeclarator(node)
 }
 
+function isReturnStatement (node) {
+    return node && node.type === 'ReturnStatement'
+}
+
 /**
  *  Utility functions to for synchronous function nodes
  * */
@@ -101,7 +105,7 @@ function isIdentifierResolveOrReject (node) {
  * @param {ReturnStatement} node 
  */
 function isReturnStatementPromise (node) {
-    return node && node.type === 'ReturnStatement' &&
+    return isReturnStatement(node) &&
         (   // return new Promise(...)
             isNewExpressionConstructingPromise(node.argument) ||
             // return Promise.resolve() or Promise.reject()

--- a/lib/rules/promise-catch.js
+++ b/lib/rules/promise-catch.js
@@ -1,3 +1,10 @@
+
+/**
+ * Recursively finds the function identifier given an AST node.
+ * The top-level call shoudl be a CallExpression.
+ * @param {ASTNode | undefined} node
+ * @returns {String | null}
+ */
 function getCalledFunctionIdentifierName (node) {
     if (node === undefined) return null
 

--- a/tests/rules/promise-catch.js
+++ b/tests/rules/promise-catch.js
@@ -172,9 +172,29 @@ eslintTester.run("promise-catch", rule, {
           { message: "Missing catch statement." }
         ],
       }, {
-        // Alternating catch-then ending in a then
+        // Alternating catch-then returning a new Promise
         code: `
           function f() { return new Promise((resolve, reject) => resolve(1)) }
+
+          f().then(x => x).catch(console.error).then(x => x)`,
+          parserOptions: { ecmaVersion: 8, sourceType: "module" },
+        errors: [
+          { message: "Missing catch statement." }
+        ],
+      }, {
+        // Alternating catch-then returning a Promise literal
+        code: `
+          function f() { return Promise.reject(123) }
+
+          f().then(x => x).catch(console.error).then(x => x)`,
+          parserOptions: { ecmaVersion: 8, sourceType: "module" },
+        errors: [
+          { message: "Missing catch statement." }
+        ],
+      }, {
+        // Alternating catch-then returning a Promise literal
+        code: `
+          function f() { return Promise.resolve(123) }
 
           f().then(x => x).catch(console.error).then(x => x)`,
           parserOptions: { ecmaVersion: 8, sourceType: "module" },

--- a/tests/rules/promise-catch.js
+++ b/tests/rules/promise-catch.js
@@ -94,7 +94,16 @@ eslintTester.run("promise-catch", rule, {
 
         y().catch(e => console.error(e)).then(x => x).catch(e => console.error(e))`,
         parserOptions: { ecmaVersion: 8, sourceType: "module" }
-    }
+    }, {
+      // Synchronous function that returns Promise
+      code: `
+      function f() {
+        return new Promise((resolve, reject) => resolve(1))
+      }
+
+      f().catch(e => console.error(e))`,
+      parserOptions: { ecmaVersion: 8, sourceType: "module" }
+    },
   ],
   invalid: [
     {
@@ -162,7 +171,17 @@ eslintTester.run("promise-catch", rule, {
         errors: [
           { message: "Missing catch statement." }
         ],
-    }
+      }, {
+        // Alternating catch-then ending in a then
+        code: `
+          function f() { return new Promise((resolve, reject) => resolve(1)) }
+
+          f().then(x => x).catch(console.error).then(x => x)`,
+          parserOptions: { ecmaVersion: 8, sourceType: "module" },
+        errors: [
+          { message: "Missing catch statement." }
+        ],
+      }
       // TODO: Instance method calls, inheritance
       // {
       //   code: `


### PR DESCRIPTION
**Features**
- Detects cases of `return new Promise()` in addition to `async` functions

**Improvements**
- Improved reliability by not throwing Errors
- Code refactoring